### PR TITLE
Refine common base viewmodels

### DIFF
--- a/helpers/tables-helper.js
+++ b/helpers/tables-helper.js
@@ -30,7 +30,7 @@
         this.composeServerOptions = function (custom, vm) {
             var options = $.extend(true, {}, baseOptions, serverOptions);
             options.ajax.data = function (data, settings) {
-                var filter = vm.MapToSave();
+                var filter = vm.mapToSave();
                 return JSON.stringify({ data: data, filter: filter });
             }
 

--- a/modules/ajax-module.js
+++ b/modules/ajax-module.js
@@ -69,20 +69,20 @@
         };
 
         this._sendEditableViewModel = function(url, vm, method, data, skipStatus) {
-            vm.BlockingStatus(new App.vms.base.BlockingStatus(true));
+            vm.blockingStatus(new App.vms.base.BlockingStatus(true));
 
             var result = this._send(url, data, method)
                 .then(function(data) {
-                    vm.BlockingStatus(new App.vms.base.BlockingStatus(false, skipStatus ? null : true));
-                    vm.Alert(new App.vms.base.AlertStatus(true, App.utils.unescape(data.message)));
+                    vm.blockingStatus(new App.vms.base.BlockingStatus(false, skipStatus ? null : true));
+                    vm.alert(new App.vms.base.AlertStatus(true, App.utils.unescape(data.message)));
 
                     return data;
                 })
                 .catch(function(data) {
-                    vm.BlockingStatus(new App.vms.base.BlockingStatus(false, false));
+                    vm.blockingStatus(new App.vms.base.BlockingStatus(false, false));
 
                     if (data && data.message) {
-                        vm.Alert(new App.vms.base.AlertStatus(false, App.utils.unescape(data.message)));
+                        vm.alert(new App.vms.base.AlertStatus(false, App.utils.unescape(data.message)));
                     }
 
                     return Promise.reject(data);

--- a/modules/ajax-module.js
+++ b/modules/ajax-module.js
@@ -49,7 +49,7 @@
          */
         this.save = function(url, vm) {
             if (vm.isValid()) {
-                return this._sendEditableViewModel(url, vm, httpMethod.POST, vm.MapToSave());
+                return this._sendEditableViewModel(url, vm, httpMethod.POST, vm.mapToSave());
             } else {
                 vm.errors.showAllMessages();
 

--- a/modules/ajax-module.js
+++ b/modules/ajax-module.js
@@ -16,7 +16,7 @@
         };
 
         /**
-         * Loading some data for editable view model @see BaseEditViewModel.
+         * Loading some data for editable view model @see Editable view model.
          *
          * @param {string} url - A string containing the URL to which the request is sent.
          * @param {Object} vm - View model that load some data.
@@ -28,7 +28,7 @@
         };
 
         /**
-         * Changing data for editable view model @see BaseEditViewModel.
+         * Changing data for editable view model @see Editable view model.
          *
          * @param {string} url - A string containing the URL to which the request is sent.
          * @param {Object} vm - View model that changed.
@@ -40,10 +40,10 @@
         };
 
         /**
-         * Saving editable and validatable view model @see BaseEditViewModel and @see BaseValidatableViewModel.
+         * Saving editable and validatable view model @see Editable and @see Editable view models.
          *
          * @param {string} url - A string containing the URL to which the request is sent.
-         * @param {Object} vm - View model for save with extended by BaseEditViewModel and BaseValidatableViewModel.
+         * @param {Object} vm - View model for save with extended by Editable and Editable view models.
          * @returns {Promise} - For valid view model return rejected or resolved Promise object.
          *                      For invalid view model return empty Promise object. Important `catch` or `then` never calls!
          */
@@ -69,20 +69,20 @@
         };
 
         this._sendEditableViewModel = function(url, vm, method, data, skipStatus) {
-            vm.BlockingStatus(new App.vms.Base.BlockingStatus(true));
+            vm.BlockingStatus(new App.vms.base.BlockingStatus(true));
 
             var result = this._send(url, data, method)
                 .then(function(data) {
-                    vm.BlockingStatus(new App.vms.Base.BlockingStatus(false, skipStatus ? null : true));
-                    vm.Alert(new App.vms.Base.AlertStatus(true, App.utils.unescape(data.message)));
+                    vm.BlockingStatus(new App.vms.base.BlockingStatus(false, skipStatus ? null : true));
+                    vm.Alert(new App.vms.base.AlertStatus(true, App.utils.unescape(data.message)));
 
                     return data;
                 })
                 .catch(function(data) {
-                    vm.BlockingStatus(new App.vms.Base.BlockingStatus(false, false));
+                    vm.BlockingStatus(new App.vms.base.BlockingStatus(false, false));
 
                     if (data && data.message) {
-                        vm.Alert(new App.vms.Base.AlertStatus(false, App.utils.unescape(data.message)));
+                        vm.Alert(new App.vms.base.AlertStatus(false, App.utils.unescape(data.message)));
                     }
 
                     return Promise.reject(data);

--- a/pages/admins/change-password-view-model.js
+++ b/pages/admins/change-password-view-model.js
@@ -4,13 +4,13 @@
     function ChangePasswordViewModel(model, router) {
         var self = this;
 
-        App.vms.Base.BaseEditViewModel.call(this);
+        App.vms.base.Editable.call(this);
 
         this.adminId = model.adminId;
         this.oldPassword = ko.observable(model.oldPassword).extend({ required: true });
         this.newPassword = ko.observable(model.newPassword).extend({ required: true });
 
-        App.vms.Base.BaseValidatableViewModel.call(this);
+        App.vms.base.Validatable.call(this);
 
         this.save = function () {
             App.ajax.save(router.changePassword(), self)

--- a/pages/admins/edit-admin-view-model.js
+++ b/pages/admins/edit-admin-view-model.js
@@ -4,7 +4,7 @@
     function EditAdminViewModel(model, options) {
         var self = this;
 
-        App.vms.Base.BaseEditViewModel.call(this);
+        App.vms.base.Editable.call(this);
 
         this.Id = model.Id;
         this.Name = ko.observable(model.Name).extend({

--- a/pages/backend/backend-item-view-model.js
+++ b/pages/backend/backend-item-view-model.js
@@ -8,7 +8,7 @@
         this.Id = ko.observable(id);
         this.Value = ko.observable().extend({ escaped: true });
 
-        this.MapToSave = function () {
+        this.mapToSave = function () {
             return JSON.stringify({ id: self.Id(), value: ko.mapping.toJSON(self.Value) });
         }
 

--- a/pages/backend/backend-item-view-model.js
+++ b/pages/backend/backend-item-view-model.js
@@ -3,7 +3,7 @@
 
     function BackendItemViewModel(id) {
         var self = this;
-        App.vms.Base.BaseEditViewModel.call(this);
+        App.vms.base.Editable.call(this);
 
         this.Id = ko.observable(id);
         this.Value = ko.observable().extend({ escaped: true });
@@ -18,7 +18,7 @@
             return false;
         }
 
-        App.vms.Base.BaseValidatableViewModel.call(this);
+        App.vms.base.Validatable.call(this);
     }
 
 

--- a/pages/backend/backend-view-model.js
+++ b/pages/backend/backend-view-model.js
@@ -43,7 +43,7 @@
 
         this.ReloadBackendTag = function (update) {
             if (self.SelectedNodeId()) {
-                self.BackendItem.BlockingStatus(new App.vms.base.BlockingStatus(true));
+                self.BackendItem.blockingStatus(new App.vms.base.BlockingStatus(true));
                 $.ajax({
                     url: App.routers.Backend.EditView(self.SelectedNodeId()),
                     data: { 'remoteReload': typeof update == 'boolean' && update },
@@ -56,11 +56,11 @@
                             ko.cleanNode(viewNode);
                             $(viewNode).replaceWith(data);
                         }
-                        self.BackendItem.Alert(new App.vms.base.AlertStatus(success, success ? null : LocalizationStrings.InternalError));
-                        self.BackendItem.BlockingStatus(new App.vms.base.BlockingStatus(false, null));
+                        self.BackendItem.alert(new App.vms.base.AlertStatus(success, success ? null : LocalizationStrings.InternalError));
+                        self.BackendItem.blockingStatus(new App.vms.base.BlockingStatus(false, null));
                     },
                     error: function () {
-                        self.BackendItem.BlockingStatus(new App.vms.base.BlockingStatus(false, false));
+                        self.BackendItem.blockingStatus(new App.vms.base.BlockingStatus(false, false));
                     }
                 });
             }

--- a/pages/backend/backend-view-model.js
+++ b/pages/backend/backend-view-model.js
@@ -43,7 +43,7 @@
 
         this.ReloadBackendTag = function (update) {
             if (self.SelectedNodeId()) {
-                self.BackendItem.BlockingStatus(new App.vms.Base.BlockingStatus(true));
+                self.BackendItem.BlockingStatus(new App.vms.base.BlockingStatus(true));
                 $.ajax({
                     url: App.routers.Backend.EditView(self.SelectedNodeId()),
                     data: { 'remoteReload': typeof update == 'boolean' && update },
@@ -56,11 +56,11 @@
                             ko.cleanNode(viewNode);
                             $(viewNode).replaceWith(data);
                         }
-                        self.BackendItem.Alert(new App.vms.Base.AlertStatus(success, success ? null : LocalizationStrings.InternalError));
-                        self.BackendItem.BlockingStatus(new App.vms.Base.BlockingStatus(false, null));
+                        self.BackendItem.Alert(new App.vms.base.AlertStatus(success, success ? null : LocalizationStrings.InternalError));
+                        self.BackendItem.BlockingStatus(new App.vms.base.BlockingStatus(false, null));
                     },
                     error: function () {
-                        self.BackendItem.BlockingStatus(new App.vms.Base.BlockingStatus(false, false));
+                        self.BackendItem.BlockingStatus(new App.vms.base.BlockingStatus(false, false));
                     }
                 });
             }

--- a/pages/base/base-edit-view-model.js
+++ b/pages/base/base-edit-view-model.js
@@ -1,7 +1,7 @@
 ﻿(function (App, $, ko) {
     'use strict';
 
-    function BaseEditViewModel(model) {
+    function BaseEditableViewModel(model) {
         var self = this;
 
         this.BlockingStatus = ko.observable();
@@ -14,7 +14,7 @@
         this.ignoreOnSave = ['ignoreOnSave', 'BlockingStatus', 'Alert'];
     }
 
-    function BaseBoxViewModel() {
+    function BaseCollapsibleViewModel() {
         var self = this;
 
         this.isCollapsed = ko.observable(false);
@@ -54,10 +54,10 @@
         }
     }
 
-    App.ns('vms.Base').BlockingStatus = BlockingStatus;
-    App.ns('vms.Base').AlertStatus = AlertStatus;
-    App.ns('vms.Base').BaseEditViewModel = BaseEditViewModel;
-    App.ns('vms.Base').BaseValidatableViewModel = BaseValidatableViewModel;
-    App.ns('vms.Base').BaseBoxViewModel = BaseBoxViewModel;
+    App.ns('vms.base').BlockingStatus = BlockingStatus;
+    App.ns('vms.base').AlertStatus = AlertStatus;
+    App.ns('vms.base').Editable = BaseEditableViewModel;
+    App.ns('vms.base').Validatable = BaseValidatableViewModel;
+    App.ns('vms.base').Collapsible = BaseCollapsibleViewModel;
 
 }(App, jQuery, ko));

--- a/pages/base/base-edit-view-model.js
+++ b/pages/base/base-edit-view-model.js
@@ -7,7 +7,7 @@
         this.blockingStatus = ko.observable();
         this.alert = ko.observable((model && model.alert) ? model.alert : null);
 
-        this.MapToSave = function () {
+        this.mapToSave = function () {
             return ko.mapping.toJSON(self, { ignore: self.ignoreOnSave });
         }
 

--- a/pages/base/base-edit-view-model.js
+++ b/pages/base/base-edit-view-model.js
@@ -4,14 +4,14 @@
     function BaseEditableViewModel(model) {
         var self = this;
 
-        this.BlockingStatus = ko.observable();
-        this.Alert = ko.observable((model && model.alert) ? model.alert : null);
+        this.blockingStatus = ko.observable();
+        this.alert = ko.observable((model && model.alert) ? model.alert : null);
 
         this.MapToSave = function () {
             return ko.mapping.toJSON(self, { ignore: self.ignoreOnSave });
         }
 
-        this.ignoreOnSave = ['ignoreOnSave', 'BlockingStatus', 'Alert'];
+        this.ignoreOnSave = ['ignoreOnSave', 'blockingStatus', 'alert'];
     }
 
     function BaseCollapsibleViewModel() {

--- a/pages/base/tables-base-view-models.js
+++ b/pages/base/tables-base-view-models.js
@@ -4,7 +4,7 @@
     function ServerTableViewModel(model) {
         var self = this;
 
-        this.MapToSave = function () {
+        this.mapToSave = function () {
             return JSON.parse(ko.mapping.toJSON(self, { ignore: self.ignoreOnSave }));
         }
 
@@ -19,7 +19,7 @@
         }
 
         ko.postbox.subscribe('search', function () {
-            App.routers.setHashData(self.MapToSave());
+            App.routers.setHashData(self.mapToSave());
         });
     }
 
@@ -54,7 +54,7 @@
             $.ajax({
                 url: typeof url === 'function' ? url() : url,
                 type: 'POST',
-                data: JSON.stringify({ filter: self.MapToSave(), format: format }),
+                data: JSON.stringify({ filter: self.mapToSave(), format: format }),
                 contentType: "application/json",
                 timeout: 5000,
                 success: function (data) {


### PR DESCRIPTION
@PowerMeMobile/poweralleyui, breaking changes:
- Changed namespace from `.vms.Base.` to `.vms.base`;
- Rename next classes:
  - `BaseEditViewModel` -> `Editable`;
  - `BaseValidatableViewModel` -> `Validatable`;
  - `BaseBoxViewModel` -> `Collapsible`;
- Rename to lowerCase fields in the `Editable` view model:
  - `Alert` -> `alert`;
  - `BlockingStatus` -> `blockingStatus`;
  - `MapToSave` -> `mapToSave`;
- Rename `MapToSave` to lowerCase in all view models.
